### PR TITLE
Fixing styles inside h4 used in content body

### DIFF
--- a/css/bundle/os-mt-kbs.css
+++ b/css/bundle/os-mt-kbs.css
@@ -2972,13 +2972,14 @@ body.body-with-sidebar {
     margin-top: 3rem;
     padding-left: 3%
 }
-[class*=columbia-breadcrumb-home-documentation-10] article h4~* {
+[class*=columbia-breadcrumb-home-documentation-10] h4 ~ .os-note {
     margin-left: 3%;
+    padding-left: 36px;
 }
-[class*=columbia-breadcrumb-home-documentation-10] header h4~* {
+[class*=columbia-breadcrumb-home-documentation-10] h4~* {
     padding-left: 3%
 }
-[class*=columbia-breadcrumb-home-documentation-10] header h4~ul li {
+[class*=columbia-breadcrumb-home-documentation-10] h4~ul li {
     margin-left: 3%
 }
 [class*=columbia-breadcrumb-home-documentation-10] table {

--- a/css/bundle/os-mt-kbs.css
+++ b/css/bundle/os-mt-kbs.css
@@ -2972,7 +2972,7 @@ body.body-with-sidebar {
     margin-top: 3rem;
     padding-left: 3%
 }
-[class*=columbia-breadcrumb-home-documentation-10] h4 ~ .os-note {
+[class*=columbia-breadcrumb-home-documentation-10] .os-note {
     margin-left: 3%;
     padding-left: 36px;
 }

--- a/css/bundle/os-mt-kbs.css
+++ b/css/bundle/os-mt-kbs.css
@@ -2972,10 +2972,13 @@ body.body-with-sidebar {
     margin-top: 3rem;
     padding-left: 3%
 }
-[class*=columbia-breadcrumb-home-documentation-10] h4~* {
+[class*=columbia-breadcrumb-home-documentation-10] article h4~* {
+    margin-left: 3%;
+}
+[class*=columbia-breadcrumb-home-documentation-10] header h4~* {
     padding-left: 3%
 }
-[class*=columbia-breadcrumb-home-documentation-10] h4~ul li {
+[class*=columbia-breadcrumb-home-documentation-10] header h4~ul li {
     margin-left: 3%
 }
 [class*=columbia-breadcrumb-home-documentation-10] table {


### PR DESCRIPTION
Currently, this h4~* declaration affects everything next to it.

See the note div here:
https://success.outsystems.com/Documentation/11/Developing_an_Application/Design_UI/Accessibility#Change_the_role_of_the_Alert_pattern

I believe this declaration is used to address the mobile version of the documentation/site menu, specifically the "Go back" bullet/icon. I tried to restrict that to the header, which I believe should suffice, but would appreciate the code review @diegoalmeida as you know this better than we do.

Thanks.